### PR TITLE
API refactoring to use vectors in Options instead of slices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "didcomm-rs"
-version = "0.7.1"
+version = "0.7.1-vec"
 authors = ["Ivan Temchenko <35359595i@gmail.com>", "Sebastian Wolfram <wulfraem@users.noreply.github.com>", "Sebastian Dechant <763247+S3bb1@users.noreply.github.com>"]
 edition = "2018"
 repository = "https://github.com/decentralized-identity/didcomm-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@
 //!     // decide which [Algorithm](crypto::encryptor::CryptoAlgorithm) is used (based on key)
 //!     .as_jwe(
 //!         &CryptoAlgorithm::XC20P,
-//!         Some(&bobs_public),
+//!         Some(bobs_public.to_vec()),
 //!     )
 //!     // add some custom app/protocol related headers to didcomm header portion
 //!     // these are not included into JOSE header
@@ -108,7 +108,7 @@
 //! // recipient public key is automatically resolved
 //! let ready_to_send = message.seal(
 //!     &ek,
-//!     Some(vec![Some(&bobs_public), Some(&carol_public)]),
+//!     Some(vec![Some(bobs_public.to_vec()), Some(carol_public.to_vec())]),
 //! ).unwrap();
 //!
 //! //... transport is happening here ...
@@ -183,7 +183,7 @@
 //!     // packing in some payload
 //!     .body(r#"{"foo":"bar"}"#)
 //!     // set JOSE header for XC20P algorithm
-//!     .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public))
+//!     .as_jwe(&CryptoAlgorithm::XC20P, Some(bobs_public.to_vec()))
 //!     // custom header
 //!     .add_header_field("my_custom_key".into(), "my_custom_value".into())
 //!     // another custom header
@@ -194,9 +194,9 @@
 //!     //**THIS MUST BE LAST IN THE CHAIN** - after this call you'll get new instance of envelope `Message` destined to the mediator.
 //!     .routed_by(
 //!         &alice_private,
-//!         Some(vec![Some(&bobs_public)]),
+//!         Some(vec![Some(bobs_public.to_vec())]),
 //!         "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
-//!         Some(&mediators_public),
+//!         Some(mediators_public.to_vec()),
 //!     );
 //! assert!(mediated.is_ok());
 //!
@@ -206,7 +206,7 @@
 //! let mediator_received = Message::receive(
 //!     &mediated.unwrap(),
 //!     Some(&mediators_private),
-//!     Some(&alice_public),
+//!     Some(alice_public.to_vec()),
 //!     None,
 //! );
 //! assert!(mediator_received.is_ok());
@@ -226,7 +226,7 @@
 //! let bob_received = Message::receive(
 //!     &String::from_utf8_lossy(&message_to_forward.payload),
 //!     Some(&bobs_private),
-//!     Some(&alice_public),
+//!     Some(alice_public.to_vec()),
 //!     None,
 //! );
 //! assert!(bob_received.is_ok());
@@ -275,7 +275,7 @@
 //!     .from("did:xyz:ulapcuhsatnpuhza930hpu34n_") // setting from
 //!     .to(&["did::xyz:34r3cu403hnth03r49g03"]) // setting to
 //!     .body(TEST_DID) // packing in some payload
-//!     .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public)) // set JOSE header for XC20P algorithm
+//!     .as_jwe(&CryptoAlgorithm::XC20P, Some(bobs_public.to_vec())) // set JOSE header for XC20P algorithm
 //!     .add_header_field("my_custom_key".into(), "my_custom_value".into()) // custom header
 //!     .add_header_field("another_key".into(), "another_value".into()) // another custom header
 //!     .kid(r#"Ef1sFuyOozYm3CEY4iCdwqxiSyXZ5Br-eUDdQXk6jaQ"#); // set kid header
@@ -283,7 +283,7 @@
 //! // Send as signed and encrypted JWS wrapped into JWE
 //! let ready_to_send = message.seal_signed(
 //!     &alice_private,
-//!     Some(vec![Some(&bobs_public)]),
+//!     Some(vec![Some(bobs_public.to_vec())]),
 //!     SignatureAlgorithm::EdDsa,
 //!     &sign_keypair.to_bytes(),
 //! ).unwrap();
@@ -294,7 +294,7 @@
 //! let received = Message::receive(
 //!     &ready_to_send,
 //!     Some(&bobs_private),
-//!     Some(&alice_public),
+//!     Some(alice_public.to_vec()),
 //!     None,
 //! ); // and now we parse received
 //! ```

--- a/tests/jwe_envelopes.rs
+++ b/tests/jwe_envelopes.rs
@@ -3,8 +3,7 @@ extern crate didcomm_rs;
 
 use didcomm_rs::{
     crypto::{CryptoAlgorithm, SignatureAlgorithm},
-    Error,
-    Message,
+    Error, Message,
 };
 use rand_core::OsRng;
 use serde_json::Value;
@@ -21,12 +20,12 @@ fn can_create_flat_jwe_json() -> Result<(), Error> {
     let message = Message::new()
         .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp")
         .to(&["did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"])
-        .as_flat_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public))
+        .as_flat_jwe(&CryptoAlgorithm::XC20P, Some(bobs_public.to_vec()))
         .kid(&hex::encode(sign_keypair.public.to_bytes()));
 
     let jwe_string = message.seal_signed(
         &alice_private,
-        Some(vec![Some(&bobs_public)]),
+        Some(vec![Some(bobs_public.to_vec())]),
         SignatureAlgorithm::EdDsa,
         &sign_keypair.to_bytes(),
     )?;
@@ -64,17 +63,22 @@ fn can_receive_flat_jwe_json() -> Result<(), Error> {
         .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp")
         .to(&["did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"])
         .body(body) // packing in some payload
-        .as_flat_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public))
+        .as_flat_jwe(&CryptoAlgorithm::XC20P, Some(bobs_public.to_vec()))
         .kid(&hex::encode(sign_keypair.public.to_bytes()));
 
     let jwe_string = message.seal_signed(
         &alice_private,
-        Some(vec![Some(&bobs_public)]),
+        Some(vec![Some(bobs_public.to_vec())]),
         SignatureAlgorithm::EdDsa,
         &sign_keypair.to_bytes(),
     )?;
 
-    let received = Message::receive(&jwe_string, Some(&bobs_private), Some(&alice_public), None);
+    let received = Message::receive(
+        &jwe_string,
+        Some(&bobs_private),
+        Some(alice_public.to_vec()),
+        None,
+    );
 
     // Assert
     assert!(&received.is_ok());

--- a/tests/jws_envelopes.rs
+++ b/tests/jws_envelopes.rs
@@ -5,8 +5,7 @@ extern crate sodiumoxide;
 pub use ddoresolver_rs::*;
 use didcomm_rs::{
     crypto::{SignatureAlgorithm, Signer},
-    Error,
-    Message,
+    Error, Message,
 };
 use rand_core::OsRng;
 use serde_json::Value;
@@ -65,7 +64,7 @@ fn can_receive_flattened_jws_json() -> Result<(), Error> {
     let received = Message::receive(
         &jws_string,
         Some(&[]),
-        Some(&sign_keypair.public.to_bytes()),
+        Some(sign_keypair.public.as_bytes().to_vec()),
         None,
     );
     assert!(received.is_ok());
@@ -91,7 +90,7 @@ fn can_receive_general_jws_json() -> Result<(), Error> {
     let received = Message::receive(
         &jws_string,
         Some(&[]),
-        Some(&sign_keypair.public.to_bytes()),
+        Some(sign_keypair.public.to_bytes().to_vec()),
         None,
     );
     assert!(received.is_ok());

--- a/tests/message_type.rs
+++ b/tests/message_type.rs
@@ -5,10 +5,7 @@ use std::str::from_utf8;
 
 use didcomm_rs::{
     crypto::{CryptoAlgorithm, SignatureAlgorithm, Signer},
-    Error,
-    JwmHeader,
-    Message,
-    MessageType,
+    Error, JwmHeader, Message, MessageType,
 };
 use rand_core::OsRng;
 use serde_json::Value;
@@ -74,12 +71,12 @@ fn sets_message_type_correctly_for_signed_and_encrypted_messages() -> Result<(),
     let message = Message::new()
         .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp")
         .to(&["did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"])
-        .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public))
+        .as_jwe(&CryptoAlgorithm::XC20P, Some(bobs_public.to_vec()))
         .kid(&hex::encode(sign_keypair.public.to_bytes()));
 
     let jwe_string = message.seal_signed(
         &alice_private,
-        Some(vec![Some(&bobs_public)]),
+        Some(vec![Some(bobs_public.to_vec())]),
         SignatureAlgorithm::EdDsa,
         &sign_keypair.to_bytes(),
     )?;
@@ -116,13 +113,13 @@ fn sets_message_type_correctly_for_forwarded_messages() -> Result<(), Error> {
     let message = Message::new()
         .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp")
         .to(&["did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"])
-        .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public));
+        .as_jwe(&CryptoAlgorithm::XC20P, Some(bobs_public.to_vec()));
 
     let jwe_string = message.routed_by(
         &alice_private,
-        Some(vec![Some(&bobs_public)]),
+        Some(vec![Some(bobs_public.to_vec())]),
         "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
-        Some(&mediators_public),
+        Some(mediators_public.to_vec()),
     )?;
 
     let jwe_object: Value = serde_json::from_str(&jwe_string)?;

--- a/tests/send_receive.rs
+++ b/tests/send_receive.rs
@@ -58,7 +58,7 @@ fn send_receive_encrypted_xc20p_json_test() {
             "did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG",
         ]) // setting to
         .body(sample_dids::TEST_DID_SIGN_1) // packing in some payload
-        .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public)) // set JOSE header for XC20P algorithm
+        .as_jwe(&CryptoAlgorithm::XC20P, Some(bobs_public.to_vec())) // set JOSE header for XC20P algorithm
         .add_header_field("my_custom_key".into(), "my_custom_value".into()) // custom header
         .add_header_field("another_key".into(), "another_value".into()) // another coustom header
         .kid(r#"#z6LShs9GGnqk85isEBzzshkuVWrVKsRp24GnDuHk8QWkARMW"#); // set kid header
@@ -67,13 +67,16 @@ fn send_receive_encrypted_xc20p_json_test() {
     let ready_to_send = message
         .seal(
             &alice_private,
-            Some(vec![Some(&bobs_public), Some(&carol_public)]),
+            Some(vec![
+                Some(bobs_public.to_vec()),
+                Some(carol_public.to_vec()),
+            ]),
         )
         .unwrap();
     let received = Message::receive(
         &ready_to_send,
         Some(&bobs_private),
-        Some(&alice_public),
+        Some(alice_public.to_vec()),
         None,
     ); // and now we parse received
 
@@ -99,21 +102,21 @@ fn send_receive_mediated_encrypted_xc20p_json_test() {
         .from("did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp")
         .to(&["did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG"])
         .body(sample_dids::TEST_DID_SIGN_1) // packing in some payload
-        .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public))
+        .as_jwe(&CryptoAlgorithm::XC20P, Some(bobs_public.to_vec()))
         .add_header_field("my_custom_key".into(), "my_custom_value".into()) // custom header
         .add_header_field("another_key".into(), "another_value".into()) // another coustom header
         .routed_by(
             &alice_private,
-            Some(vec![Some(&bobs_public)]),
+            Some(vec![Some(bobs_public.to_vec())]),
             "did:key:z6MknGc3ocHs3zdPiJbnaaqDi58NGb4pk1Sp9WxWufuXSdxf",
-            Some(&mediators_public),
+            Some(mediators_public.to_vec()),
         );
     assert!(sealed.is_ok());
 
     let mediator_received = Message::receive(
         &sealed.unwrap(),
         Some(&mediators_private),
-        Some(&alice_public),
+        Some(alice_public.to_vec()),
         None,
     );
     assert!(mediator_received.is_ok());
@@ -129,7 +132,7 @@ fn send_receive_mediated_encrypted_xc20p_json_test() {
     let bob_received = Message::receive(
         &String::from_utf8_lossy(&message_to_forward.payload),
         Some(&bobs_private),
-        Some(&alice_public),
+        Some(alice_public.to_vec()),
         None,
     );
     assert!(bob_received.is_ok());
@@ -195,7 +198,7 @@ fn send_receive_direct_signed_and_encrypted_xc20p_test() {
             "did:xyz:30489jnutnjqhiu0uh540u8hunoe",
         ]) // setting to
         .body(sample_dids::TEST_DID_SIGN_1) // packing in some payload
-        .as_jwe(&CryptoAlgorithm::XC20P, Some(&bobs_public)) // set JOSE header for XC20P algorithm
+        .as_jwe(&CryptoAlgorithm::XC20P, Some(bobs_public.to_vec())) // set JOSE header for XC20P algorithm
         .add_header_field("my_custom_key".into(), "my_custom_value".into()) // custom header
         .add_header_field("another_key".into(), "another_value".into()) // another custom header
         .kid(&hex::encode(sign_keypair.public.to_bytes())); // set kid header
@@ -205,7 +208,10 @@ fn send_receive_direct_signed_and_encrypted_xc20p_test() {
     let ready_to_send = message
         .seal_signed(
             &alice_private,
-            Some(vec![Some(&bobs_public), Some(&carol_public)]),
+            Some(vec![
+                Some(bobs_public.to_vec()),
+                Some(carol_public.to_vec()),
+            ]),
             SignatureAlgorithm::EdDsa,
             &sign_keypair.to_bytes(),
         )
@@ -216,7 +222,7 @@ fn send_receive_direct_signed_and_encrypted_xc20p_test() {
     let received = Message::receive(
         &ready_to_send,
         Some(&bobs_private),
-        Some(&alice_public),
+        Some(alice_public.to_vec()),
         None,
     );
     #[cfg(feature = "resolve")]


### PR DESCRIPTION
Ran into an issue with `Option<&[u8]>` public key API in `.as_jwe()` method, where converting from referred `Vec` or `Option<&Vec>` becomes really annoying. We are anyways heavy std dependent anyways right now.
Any objections? =)