### PR TITLE
Fix typo in API name and remove redundant serde attribute

### DIFF
--- a/src/messages/attachment.rs
+++ b/src/messages/attachment.rs
@@ -257,7 +257,7 @@ impl Message {
     ///
     /// * `builder` - prepopulated instance of `AttachmentBuilder`
     ///
-    pub fn apeend_attachment(&mut self, builder: AttachmentBuilder) {
+    pub fn append_attachment(&mut self, builder: AttachmentBuilder) {
         self.attachments.push(builder.finalize());
     }
 

--- a/src/messages/headers/decorators.rs
+++ b/src/messages/headers/decorators.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 /// A `~thread` message decorator that provides request/reply
 /// and threading semantics according to Aries RFC 0008.
 #[derive(Default, Deserialize, Serialize, PartialEq, Debug, Clone)]
-#[serde(default)]
 pub struct Thread {
     /// The ID of the message that serves as the thread start.
     pub thid: String,

--- a/src/messages/out_of_band.rs
+++ b/src/messages/out_of_band.rs
@@ -18,7 +18,7 @@ impl Message {
             serde_json::to_string(&MessageType::DidCommInvitation).unwrap();
         if let Some(attachments) = attachments {
             for attachment in attachments {
-                self.apeend_attachment(attachment);
+                self.append_attachment(attachment);
             }
         }
         self.body(std::str::from_utf8(body.as_ref()).unwrap())


### PR DESCRIPTION
Fix typo in API name. This is breaking compatibility change.