### PR TITLE
adjust get_did function to match did spec

### DIFF
--- a/src/messages/helpers/encryption.rs
+++ b/src/messages/helpers/encryption.rs
@@ -392,7 +392,7 @@ fn get_did_from_didurl(url: &str) -> String {
             [a-z]+          # method
             :
             (?:[a-z]*:)*    # optional subdomains, postfixed with a ':'
-            [a-zA-Z0-9]+    # method specific identifier
+            [a-zA-Z0-9.\-_%]+    # method specific identifier
         )
         (?:/[^?\#]*)?        # optional path
         (?:\?[^\#]*)?        # optional query


### PR DESCRIPTION
Small fix to adjust the `get_did_from_didurl` function to match the current did core spec. This defines that a DID is identified by:

```
method-specific-id = *( *idchar ":" ) 1*idchar
idchar             = ALPHA / DIGIT / "." / "-" / "_" / pct-encoded
pct-encoded        = "%" HEXDIG HEXDIG
````
previously the `.`, `-`, `_` and the `%` were not captured in the regex


