### PR TITLE
upgrade uuid version to 1.1 and fake to 2.5 to make tests run

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ ddoresolver-rs = { version = "0.4.2", default-features = false, features = ["did
 x25519-dalek = "1.1"
 arrayref = "0.3"
 chrono = "0.4"
-uuid = { version = "0.8.2", features = ["v4"] }
+uuid = { version = "1.1.2", features = ["v4"] }
 sha2 = "0.8.1"
 
 # Other
@@ -51,7 +51,7 @@ base58 = "0.2.0"
 utilities = { path = "./utilities" }
 quickcheck = "1"
 quickcheck_macros = "1"
-fake = { version = "2.4", features = ["uuid"] }
+fake = { version = "2.5.0", features = ["uuid"] }
 
 [dev-dependencies.cargo-husky]
 version = "1"


### PR DESCRIPTION
# Description
uuid version 0.8 is incompatible with fake 2.4.
This merge request will upgrade versions to make the tests run.
# Testing
Currently the tests error:
```sh
~/temp/didcomm-rs$ cargo test
   Compiling didcomm-rs v0.7.2 (/home/chriamue/temp/didcomm-rs)
error[E0277]: the trait bound `Uuid: Dummy<UUIDv4>` is not satisfied
   --> src/messages/headers/decorators.rs:129:34
    |
129 |             let s: Uuid = UUIDv4.fake();
    |                                  ^^^^ the trait `Dummy<UUIDv4>` is not implemented for `Uuid`
    |
    = help: the following other types implement trait `Dummy<T>`:
              <&str as Dummy<BsAdj<L>>>
              <&str as Dummy<BsNoun<L>>>
              <&str as Dummy<BsVerb<L>>>
              <&str as Dummy<Buzzword<L>>>
              <&str as Dummy<BuzzwordMiddle<L>>>
              <&str as Dummy<BuzzwordTail<L>>>
              <&str as Dummy<CityPrefix<L>>>
              <&str as Dummy<CitySuffix<L>>>
            and 352 others
    = note: required because of the requirements on the impl of `fake::private::FakeBase<Uuid>` for `UUIDv4`
note: required by a bound in `fake`
   --> /home/chriamue/.cargo/registry/src/github.com-1ecc6299db9ec823/fake-2.5.0/src/lib.rs:186:15
    |
186 |         Self: private::FakeBase<U>,
    |               ^^^^^^^^^^^^^^^^^^^^ required by this bound in `fake`

error[E0277]: the trait bound `Uuid: Dummy<UUIDv4>` is not satisfied
   --> src/messages/headers/decorators.rs:136:34
    |
136 |             let s: Uuid = UUIDv4.fake();
    |                                  ^^^^ the trait `Dummy<UUIDv4>` is not implemented for `Uuid`
    |
    = help: the following other types implement trait `Dummy<T>`:
              <&str as Dummy<BsAdj<L>>>
              <&str as Dummy<BsNoun<L>>>
              <&str as Dummy<BsVerb<L>>>
              <&str as Dummy<Buzzword<L>>>
              <&str as Dummy<BuzzwordMiddle<L>>>
              <&str as Dummy<BuzzwordTail<L>>>
              <&str as Dummy<CityPrefix<L>>>
              <&str as Dummy<CitySuffix<L>>>
            and 352 others
    = note: required because of the requirements on the impl of `fake::private::FakeBase<Uuid>` for `UUIDv4`
note: required by a bound in `fake`
   --> /home/chriamue/.cargo/registry/src/github.com-1ecc6299db9ec823/fake-2.5.0/src/lib.rs:186:15
    |
186 |         Self: private::FakeBase<U>,
    |               ^^^^^^^^^^^^^^^^^^^^ required by this bound in `fake`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `didcomm-rs` due to 2 previous errors
```

On changed versions, the tests run.