### PR TITLE
changed didcomm header type for oob invitation to be a string not a json

### DIFF
--- a/src/messages/out_of_band.rs
+++ b/src/messages/out_of_band.rs
@@ -14,8 +14,11 @@ impl Message {
         attachments: Option<Vec<AttachmentBuilder>>,
     ) -> Self {
         self.jwm_header.typ = MessageType::DidCommRaw;
-        self.didcomm_header.m_type =
-            serde_json::to_string(&MessageType::DidCommInvitation).unwrap();
+        self.didcomm_header.m_type = serde_json::to_value(&MessageType::DidCommInvitation)
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
         if let Some(attachments) = attachments {
             for attachment in attachments {
                 self.append_attachment(attachment);

--- a/tests/out_of_band.rs
+++ b/tests/out_of_band.rs
@@ -1,0 +1,26 @@
+extern crate didcomm_rs;
+
+use didcomm_rs::{Error, Message};
+use serde_json::Value;
+
+#[test]
+#[cfg(feature = "out-of-band")]
+fn sets_m_type_correctly_for_out_of_band_invitation_message() -> Result<(), Error> {
+    let message = Message::new()
+        .as_out_of_band_invitation("{}", None)
+        .as_raw_json()
+        .unwrap();
+
+    let object: Value = serde_json::from_str(&message)?;
+
+    assert_ne!(
+        object["type"].as_str().ok_or(Error::JwmHeaderParseError)?,
+        "\"https://didcomm.org/out-of-band/2.0/invitation\"",
+    );
+    assert_eq!(
+        object["type"].as_str().ok_or(Error::JwmHeaderParseError)?,
+        "https://didcomm.org/out-of-band/2.0/invitation",
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
# description
When converted message to out of band message,
the header message type is the json value "https://didcomm.org/out-of-band/2.0/invitation" which
results in string "\"https://didcomm.org/out-of-band/2.0/invitation\"".
This merge request makes a serialized message compatible to this https://identity.foundation/didcomm-messaging/spec/#invitation example, where "type" is a string, not a stringified json string.
# test
```rust
assert_ne!(
        message["type"].as_str()?,
        "\"https://didcomm.org/out-of-band/2.0/invitation\"",
    );
assert_eq!(
        message["type"].as_str()?,
        "https://didcomm.org/out-of-band/2.0/invitation",
    );
```
