### PR TITLE
Add new APIs to message and builder

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,8 @@ pub enum Error {
     SystemTimeError(#[from] std::time::SystemTimeError),
     #[error(transparent)]
     Base64DecodeError(#[from] base64_url::base64::DecodeError),
+    #[error("invalid attachment{0}")]
+    AttachmentError(String),
     #[error(transparent)]
     Other(Box<dyn std::error::Error>),
 }

--- a/src/messages/message.rs
+++ b/src/messages/message.rs
@@ -16,10 +16,10 @@ use crate::Result;
 
 #[cfg(feature = "raw-crypto")]
 use crate::crypto::{CryptoAlgorithm, Cypher, SignatureAlgorithm, Signer};
-use crate::{
-    helpers::{encrypt_cek, get_crypter_from_header, get_message_type, receive_jwe, receive_jws},
-    Error, Jwe, MessageType, PriorClaims, Recipient,
+use crate::helpers::{
+    encrypt_cek, get_crypter_from_header, get_message_type, receive_jwe, receive_jws,
 };
+use crate::{Error, Jwe, MessageType, PriorClaims, Recipient};
 
 /// DIDComm message structure.
 ///

--- a/tests/out_of_band.rs
+++ b/tests/out_of_band.rs
@@ -1,11 +1,10 @@
-extern crate didcomm_rs;
-
 use didcomm_rs::{Error, Message};
-use serde_json::Value;
 
 #[test]
 #[cfg(feature = "out-of-band")]
 fn sets_m_type_correctly_for_out_of_band_invitation_message() -> Result<(), Error> {
+    use serde_json::Value;
+
     let message = Message::new()
         .as_out_of_band_invitation("{}", None)?
         .as_raw_json()


### PR DESCRIPTION
Implement `TryFrom<(&str, T)` for `AttachmentBuilder` where `T:serde::Serialise`

Add `Message::deserialize_attachments` to `Message`. This will allow us to deserialize all the attachments of the given format into `T`